### PR TITLE
Correct the JSON packet format to be acceptable by concentrator

### DIFF
--- a/src/test/scala/fromdolphin/BasicSimulation.scala
+++ b/src/test/scala/fromdolphin/BasicSimulation.scala
@@ -26,8 +26,6 @@ class BasicSimulation extends Simulation {
       .pause(10)
 
       .exec(ws("Close WS").close)
-
-    println(s"ReqMsgs.getCreateSessionMsg.toString(): ${ReqMsgs.getCreateSessionMsg.toString()}")
   }
 
   val httpConf = http

--- a/src/test/scala/fromdolphin/BasicSimulation.scala
+++ b/src/test/scala/fromdolphin/BasicSimulation.scala
@@ -26,6 +26,8 @@ class BasicSimulation extends Simulation {
       .pause(10)
 
       .exec(ws("Close WS").close)
+
+    println(s"ReqMsgs.getCreateSessionMsg.toString(): ${ReqMsgs.getCreateSessionMsg.toString()}")
   }
 
   val httpConf = http
@@ -44,5 +46,5 @@ class BasicSimulation extends Simulation {
   // Single user
   //setUp(scn.inject(atOnceUsers(1)).protocols(httpConf))
 
-  setUp(scn.inject(rampUsers(1000) over (60 seconds)).protocols(httpConf))
+  setUp(scn.inject(rampUsers(10) over (20 seconds)).protocols(httpConf))
 }

--- a/src/test/scala/fromdolphin/ReqMsgs.scala
+++ b/src/test/scala/fromdolphin/ReqMsgs.scala
@@ -9,13 +9,13 @@ object ReqMsgs {
   var transactionId = 1
 
   val createSessionMsg = Json.obj(
-    "2" -> 5,
-    "5" -> 5,
-    "3" -> "",
-    "21" ->  accessToken,
-    "10" -> 16,
-    "19" -> 200,
-    "18" -> 64
+    "2" -> 5,                 // client_type or client_version
+    "5" -> 5,                 // client_type or client_version
+    "3" -> "",                // session_id
+    "21" ->  accessToken,     // access_token
+    "10" -> 16,               // font_height
+    "19" -> 200,              // sticker_pixel_size
+    "18" -> 64                // virtual_gift_pixel_size
   )
 
   def getReqMsg(packetType: Int, fields: JsValue = Json.obj()) = {

--- a/src/test/scala/fromdolphin/ReqMsgs.scala
+++ b/src/test/scala/fromdolphin/ReqMsgs.scala
@@ -4,29 +4,26 @@ import play.api.libs.json.{JsValue, Json}
 
 object ReqMsgs {
 
-  val accessToken = "0999c08a7b7c467f999724ce6f16bd37a9d1d72d994d4549bafc0e96dddcfda8"
+  val accessToken = "d701e45abaea453c8075ff06c6b9593d0fda1eb9a0ee41e4aedad96daf7944e5"
 
   var transactionId = 1
 
   val createSessionMsg = Json.obj(
-    "client_type" -> 5,
-    "client_version" -> 5,
-    "session_id" -> "",
-    "access_token" ->  accessToken,
-    "font_height" -> 16,
-    "sticker_pixel_size" -> 200,
-    "virtual_gift_pixel_size" -> 64
+    "2" -> 5,
+    "5" -> 5,
+    "3" -> "",
+    "21" ->  accessToken,
+    "10" -> 16,
+    "19" -> 200,
+    "18" -> 64
   )
 
   def getReqMsg(packetType: Int, fields: JsValue = Json.obj()) = {
     transactionId += 1
     Json.obj(
-      "createTime" -> java.lang.System.currentTimeMillis(),
-      "fields" -> fields,
-      "retryCount" -> 0,
-      "sentTime" -> java.lang.System.currentTimeMillis(),
-      "transactionId" -> transactionId,
-      "type" -> packetType
+      "F" -> fields,
+      "I" -> transactionId,
+      "T" -> packetType
     )
   }
 


### PR DESCRIPTION
From the client, Ferry use the packet.toJSON method to compress the JSON object.
